### PR TITLE
feat: player endpoint types & more goodies

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -74,7 +74,7 @@ export default class HockeyTech {
      * Retrieves the Player Profile => Bio (Header section)
      * @param playerId number
      */
-    getPlayerProfileBio(playerId: number): Promise<any>;
+    getPlayerProfileBio(playerId: number): Promise<SiteKitPlayerBioResponse>;
 
     /**
      * Retrieves the Player Profile => Player Media
@@ -260,7 +260,7 @@ export default class HockeyTech {
      * Searches for a person
      * @param searchTerm string
      */
-    searchPerson(searchTerm: string): Promise<any>;
+    searchPerson(searchTerm: string): Promise<SiteKitSearchPlayersResponse>;
 
     /**
      * Retrieves the game preview
@@ -474,6 +474,84 @@ export interface SiteKitGamesPerDay {
 
 export interface GamesPerDayResponse {
     SiteKit: SiteKitGamesPerDay;
+}
+
+export interface SearchPlayersResult {
+    person_id: string;
+    player_id: string;
+    active: string;
+    first_name: string;
+    last_name: string;
+    phonetic_name: string;
+    shoots: string;
+    catches: string;
+    height: string;
+    weight: string;
+    rawbirthdate: string;
+    birthdate: string;
+    birthtown: string;
+    birthprov: string;
+    birthcntry: string;
+    team_id: string;
+    jersey_number: string;
+    role_id: string;
+    season_id: string;
+    role_name: string;
+    all_roles: string;
+    last_team_name: string;
+    last_team_code: string;
+    division: string;
+    position: string;
+    profile_image: string;
+    score: string;
+    last_active_date: string;
+}
+
+export interface SiteKitSearchPlayers extends SiteKit {
+    Searchplayers: SearchPlayersResult[];
+}
+
+export interface SiteKitSearchPlayersResponse {
+    SiteKit: SiteKitSearchPlayers
+}
+
+export interface PlayerBio {
+    first_name: string;
+    last_name: string;
+    jersey_number: string;
+    most_recent_team_id: string;
+    most_recent_team_name: string;
+    most_recent_team_code: string;
+    division: string;
+    active: string;
+    rookie: string;
+    position: string;
+    height: string;
+    weight: string;
+    birthdate: string;
+    shoots: string;
+    catches: string;
+    bio: string;
+    name: string;
+    primary_image: string;
+    birthtown: string;
+    birthprov: string;
+    birthcntry: string;
+    hometown: string;
+    homeprov: string;
+    homecntry: string;
+    draft: Array<unknown>,
+    draft_type: string;
+    careerhigh: string;
+    current_team: string;
+}
+
+export interface SiteKitPlayerBio extends SiteKit {
+    Player: PlayerBio;
+}
+
+export interface SiteKitPlayerBioResponse {
+    SiteKit: SiteKitPlayerBio
 }
 
 export interface GoalSummary {

--- a/index.d.ts
+++ b/index.d.ts
@@ -82,7 +82,7 @@ export default class HockeyTech {
      * but it is like this in the documentation
      * @param personId number
      */
-    getPlayerProfileMedia(personId: number): Promise<any>;
+    getPlayerProfileMedia(personId: number): Promise<SiteKitPlayerMediaResponse>;
 
     /**
      * Retrieves the player's stats by season
@@ -766,6 +766,33 @@ export interface SiteKitPlayerGameByGameStats extends SiteKit {
 
 export interface SiteKitPlayerGameByGameStatsResponse {
     SiteKit: SiteKitPlayerGameByGameStats;
+}
+
+export interface PlayerMedia {
+    id: string;
+    person_id: string;
+    media_type: string;
+    lang_id: string;
+    title: string;
+    uploaded: string;
+    is_primary: string;
+    uploaded_name: string;
+    file_name: string;
+    modified: string;
+    deleted: string;
+    height: string;
+    width: string;
+    player_id: string;
+    thumb: string;
+    url: string;
+}
+
+export interface SiteKitPlayerMedia extends SiteKit {
+    Player: PlayerMedia[];
+}
+
+export interface SiteKitPlayerMediaResponse {
+    SiteKit: SiteKitPlayerMedia;
 }
 
 export interface GoalSummary {

--- a/index.d.ts
+++ b/index.d.ts
@@ -88,7 +88,7 @@ export default class HockeyTech {
      * Retrieves the player's stats by season
      * @param playerId number
      */
-    getPlayerProfileStatsBySeason(playerId: number): Promise<any>;
+    getPlayerProfileStatsBySeason(playerId: number): Promise<SiteKitPlayerStatsBySeasonResponse>;
 
     /**
      * Retrieves the player's game by game stats
@@ -552,6 +552,111 @@ export interface SiteKitPlayerBio extends SiteKit {
 
 export interface SiteKitPlayerBioResponse {
     SiteKit: SiteKitPlayerBio
+}
+
+export interface PlayerSeasonStat {
+    season_id: string;
+    season_name: string;
+    shortname: string;
+    playoff: string;
+    career: string;
+    max_start_date: string;
+    veteran_status: string;
+    veteran: string;
+    jersey_number: string;
+    goals: string;
+    games_played: string;
+    assists: string;
+    points: string;
+    plus_minus: string;
+    penalty_minutes: string;
+    power_play_goals: string;
+    power_play_assists: string;
+    shots: string;
+    shootout_attempts: string;
+    shootout_goals: string;
+    shootout_percentage: string;
+    shooting_percentage: string;
+    shootout_winning_goals: string;
+    points_per_game: string;
+    short_handed_goals: string;
+    short_handed_assists: string;
+    game_winning_goals: string;
+    game_tieing_goals: string;
+    faceoff_wins: string;
+    faceoff_attempts: string;
+    faceoff_pct: string;
+    hits: string;
+    team_name: string;
+    team_code: string;
+    team_city: string;
+    team_nickname: string;
+    team_id: string;
+    active: string;
+    first_goals: string;
+    insurance_goals: string;
+    overtime_goals: string;
+    unassisted_goals: string;
+    empty_net_goals: string;
+    penalty_minutes_per_game: string;
+    division: string;
+}
+
+export interface PlayerSeasonStatTotal {
+    season_name: string;
+    shortname: string;
+    playoff: number;
+    season_id: number;
+    career: number;
+    max_start_date: number;
+    veteran_status: number;
+    jersey_number: number;
+    goals: number;
+    games_played: number;
+    assists: number;
+    points: number;
+    plus_minus: number;
+    penalty_minutes: number;
+    power_play_goals: number;
+    power_play_assists: number;
+    shots: number;
+    shootout_attempts: number;
+    shootout_goals: number;
+    shootout_percentage: string;
+    shooting_percentage: string;
+    shootout_winning_goals: number;
+    points_per_game: string;
+    short_handed_goals: number;
+    short_handed_assists: number;
+    game_winning_goals: number;
+    game_tieing_goals: number;
+    faceoff_wins: number;
+    faceoff_attempts: number;
+    faceoff_pct: number;
+    hits: number;
+    first_goals: number;
+    insurance_goals: number;
+    overtime_goals: number;
+    unassisted_goals: number;
+    empty_net_goals: number;
+    penalty_minutes_per_game: string;
+}
+
+export interface PlayerStatsBySeason {
+    /** Includes a final "Total" object, summarizing the prior elements */
+    regular?: Array<PlayerSeasonStat | PlayerSeasonStatTotal>;
+    /** Preseason. See `regular` comment */
+    exhibition?: Array<PlayerSeasonStat | PlayerSeasonStatTotal>;
+    /** Postseason. See `regular` comment */
+    playoff?: Array<PlayerSeasonStat | PlayerSeasonStatTotal>;
+}
+
+export interface SiteKitPlayerStatsBySeason extends SiteKit {
+    Player: PlayerStatsBySeason;
+}
+
+export interface SiteKitPlayerStatsBySeasonResponse {
+    SiteKit: SiteKitPlayerStatsBySeason
 }
 
 export interface GoalSummary {

--- a/index.d.ts
+++ b/index.d.ts
@@ -287,6 +287,8 @@ export default class HockeyTech {
     getGameSummary(gameId: number): Promise<GameSummaryResponse>;
 }
 
+export type NumericBoolean = "1" | "0";
+
 export interface StatViewTypeConfigOptions {
     /**
      * Defaults to 0
@@ -384,6 +386,13 @@ export interface TeamsBySeasonResponse {
     SiteKit: SiteKitTeamsBySeason;
 }
 
+export enum GameStatus {
+    NotStarted = "1",
+    InProgress = "2",
+    // 3 might be unused
+    Final = "4",
+}
+
 export interface Schedule {
     id: string;
     game_id: string;
@@ -399,24 +408,24 @@ export interface Schedule {
     home_goal_count: string;
     visiting_goal_count: string;
     period: string;
-    overtime: string;
+    overtime: NumericBoolean;
     schedule_time: string;
     schedule_notes: string;
     game_clock: string;
     timezone: string;
     game_number: string;
-    shootout: string;
+    shootout: NumericBoolean;
     attendance: string;
-    status: string;
+    status: GameStatus;
     location: string;
     game_status: string;
-    intermission: string;
+    intermission: NumericBoolean;
     game_type: string;
     game_letter: string;
-    if_necessary: string;
+    if_necessary: NumericBoolean;
     period_trans: string;
     started: string;
-    final: string;
+    final: NumericBoolean;
     tickets_url: string;
     home_audio_url: string;
     home_video_url: string;
@@ -437,7 +446,7 @@ export interface Schedule {
     visiting_team_division_long: string;
     visiting_team_division_short: string;
     notes_text: string;
-    use_shootouts: string;
+    use_shootouts: NumericBoolean;
     venue_name: string;
     venue_url: string;
     venue_location: string;
@@ -479,7 +488,7 @@ export interface GamesPerDayResponse {
 export interface SearchPlayersResult {
     person_id: string;
     player_id: string;
-    active: string;
+    active: NumericBoolean;
     first_name: string;
     last_name: string;
     phonetic_name: string;
@@ -523,8 +532,8 @@ export interface PlayerBio {
     most_recent_team_name: string;
     most_recent_team_code: string;
     division: string;
-    active: string;
-    rookie: string;
+    active: NumericBoolean;
+    rookie: NumericBoolean;
     position: string;
     height: string;
     weight: string;
@@ -592,7 +601,7 @@ export interface PlayerSeasonStat {
     team_city: string;
     team_nickname: string;
     team_id: string;
-    active: string;
+    active: NumericBoolean;
     first_goals: string;
     insurance_goals: string;
     overtime_goals: string;
@@ -775,11 +784,11 @@ export interface PlayerMedia {
     lang_id: string;
     title: string;
     uploaded: string;
-    is_primary: string;
+    is_primary: NumericBoolean;
     uploaded_name: string;
     file_name: string;
     modified: string;
-    deleted: string;
+    deleted: NumericBoolean;
     height: string;
     width: string;
     player_id: string;
@@ -925,8 +934,8 @@ export interface GamesByDate {
     visiting_manager: string;
     period: string;
     game_clock: string;
-    status: string;
-    started: string;
+    status: GameStatus;
+    started: NumericBoolean;
     pending_final: string;
     final: string;
     home_goal_count: string;
@@ -1032,7 +1041,7 @@ export interface Meta {
     visiting_manager: string;
     period: string;
     game_clock: string;
-    status: string;
+    status: GameStatus;
     started: string;
     pending_final: string;
     final: string;
@@ -1082,7 +1091,7 @@ export interface HomeOrVisitor {
     country: string;
     phone: string;
     fax: string;
-    active: string;
+    active: NumericBoolean;
     placeholder: string;
     team_id: string;
     lang_id: string;
@@ -1401,10 +1410,7 @@ export interface ScorebarMatch {
     VisitorRegulationLosses: string;
     VisitorOTLosses: string;
     VisitorShootoutLosses: string;
-    /**
-     * @param GameStatus 2=In Progress
-     */
-    GameStatus: string;
+    GameStatus: GameStatus;
     Intermission: string;
     GameStatusString: string;
     GameStatusStringLong: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -656,7 +656,7 @@ export interface SiteKitPlayerStatsBySeason extends SiteKit {
 }
 
 export interface SiteKitPlayerStatsBySeasonResponse {
-    SiteKit: SiteKitPlayerStatsBySeason
+    SiteKit: SiteKitPlayerStatsBySeason;
 }
 
 export interface PlayerCurrentSeasonStats {

--- a/index.d.ts
+++ b/index.d.ts
@@ -100,7 +100,7 @@ export default class HockeyTech {
      * Retrieves the player's current season stats
      * @param playerId number
      */
-    getPlayerProfileCurrentSeasonStats(playerId: number): Promise<any>;
+    getPlayerProfileCurrentSeasonStats(playerId: number): Promise<SiteKitPlayerCurrentSeasonStatsResponse>;
 
     /**
      * Retrieves the season list
@@ -657,6 +657,62 @@ export interface SiteKitPlayerStatsBySeason extends SiteKit {
 
 export interface SiteKitPlayerStatsBySeasonResponse {
     SiteKit: SiteKitPlayerStatsBySeason
+}
+
+export interface PlayerCurrentSeasonStats {
+    player_id: string;
+    first_name: string;
+    last_name: string;
+    season_id: string;
+    season_name: string;
+    team_id: string;
+    team_name: string;
+    division: string;
+    games_played: string;
+    game_winning_goals: string;
+    game_tieing_goals: string;
+    first_goals: string;
+    insurance_goals: string;
+    unassisted_goals: string;
+    empty_net_goals: string;
+    overtime_goals: string;
+    ice_time: string;
+    ice_time_avg: string;
+    goals: string;
+    shots: string;
+    shooting_percentage: string;
+    assists: string;
+    points: string;
+    points_per_game: string;
+    plus_minus: string;
+    penalty_minutes: string;
+    penalty_minutes_per_game: string;
+    minor_penalties: string;
+    major_penalties: string;
+    power_play_goals: string;
+    power_play_assists: string;
+    power_play_points: string;
+    short_handed_goals: string;
+    short_handed_assists: string;
+    short_handed_points: string;
+    shootout_goals: string;
+    shootout_attempts: string;
+    shootout_winning_goals: string;
+    shootout_games_played: string;
+    faceoff_attempts: string;
+    faceoff_wins: string;
+    faceoff_pct: string;
+    faceoff_wa: string;
+    shots_on: string;
+    shootout_percentage: string;
+}
+
+export interface SiteKitPlayerCurrentSeasonStats extends SiteKit {
+    Player: PlayerCurrentSeasonStats;
+}
+
+export interface SiteKitPlayerCurrentSeasonStatsResponse {
+    SiteKit: SiteKitPlayerCurrentSeasonStats
 }
 
 export interface GoalSummary {

--- a/index.d.ts
+++ b/index.d.ts
@@ -94,7 +94,7 @@ export default class HockeyTech {
      * Retrieves the player's game by game stats
      * @param playerId number
      */
-    getPlayerProfileGameByGameStats(playerId: number): Promise<any>;
+    getPlayerProfileGameByGameStats(playerId: number): Promise<SiteKitPlayerGameByGameStatsResponse>;
 
     /**
      * Retrieves the player's current season stats
@@ -712,7 +712,60 @@ export interface SiteKitPlayerCurrentSeasonStats extends SiteKit {
 }
 
 export interface SiteKitPlayerCurrentSeasonStatsResponse {
-    SiteKit: SiteKitPlayerCurrentSeasonStats
+    SiteKit: SiteKitPlayerCurrentSeasonStats;
+}
+
+export interface PlayerGameByGameStatsGame {
+    gMonth: string;
+    id: string;
+    home_team: string;
+    visiting_team: string;
+    date_played: string;
+    home: string;
+    shots: string;
+    goalie: string;
+    home_team_code: string;
+    home_team_name: string;
+    home_division: string;
+    visiting_team_code: string;
+    visiting_team_name: string;
+    visiting_division: string;
+    goals: string;
+    plusminus: string;
+    assists: string;
+    shootout_goals: string;
+    shootout_attempts: string;
+    shootout_goals_win: string;
+    shootout_shots: string;
+    penalty_minutes: string;
+    shooting_percentage: string;
+    shootout_shots_percentage: number,
+    points: number,
+    player_team: string;
+    plus_minus: string;
+    power_play_goals: string;
+    short_handed_goals: string;
+    empty_net_goals: string;
+    /** Insurance goals */
+    insurange_goals: string;
+    game_winning_goals: string;
+    first_goals_scored: string;
+    game_tieing_goals: string;
+    faceoffs_taken: string;
+    faceoffs_won: string;
+}
+
+export interface PlayerGameByGameStats {
+    games: PlayerGameByGameStatsGame[];
+    seasons_played: { season_id: number; season_name: string }[];
+}
+
+export interface SiteKitPlayerGameByGameStats extends SiteKit {
+    Player: PlayerGameByGameStats;
+}
+
+export interface SiteKitPlayerGameByGameStatsResponse {
+    SiteKit: SiteKitPlayerGameByGameStats;
 }
 
 export interface GoalSummary {


### PR DESCRIPTION
Hi, me again. A couple of the endpoints I'm using weren't typed explicitly so I touched them up. I also added a `GameStatus` enum (1, 2, 4 - what's 3?) and a `NumericBoolean` type for those `0` or `1` strings that they use (I might have missed a few). I tried to keep in the style of your existing code, of course feel free to review if it's unsatisfactory.

A number of other endpoints remain typed as `any` but I don't think I'll be using most of them in my application particularly soon so I decided to PR what I have.

- [x] `getPlayerProfileMedia`
- [x] `getPlayerProfileGameByGameStats`
- [x] `getPlayerProfileCurrentSeasonStats`
- [x] `getPlayerProfileStatsBySeason`
- [x] `getPlayerProfileBio`